### PR TITLE
Fix Python version matrix, dependency categorization, and comments

### DIFF
--- a/inception/embed_endpoint.py
+++ b/inception/embed_endpoint.py
@@ -174,7 +174,7 @@ class QueryRequest(BaseModel):
 class QueryResponse(BaseModel):
     embedding: List[float]
 
-#although we are doing preprocessing here, we needto decide if we want to do it here or in the client script that wwill be sending opinions for embedding 
+#although we are doing preprocessing here, we need to decide if we want to do it here or in the client script that will be sending opinions for embedding 
 def clean_text_for_json(text: str) -> str:
     """
     Clean and prepare text for JSON encoding.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,10 @@ numpy = "^1.26.1"
 gunicorn = "^21.2.0"
 prometheus-client = "^0.19.0"
 sentry-sdk = {extras = ["fastapi"], version = "^1.32.0"}
-black = "^23.11.0"
-mypy = "^1.7.0"
 
 [tool.poetry.group.dev.dependencies]
+black = "^23.11.0"
+mypy = "^1.7.0"
 pytest = "^7.4.3"
 pytest-cov = "^4.1.0"
 httpx = "^0.25.1"

--- a/test.yml
+++ b/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
       fail-fast: false  # Continue with other versions if one fails
 
     steps:
@@ -60,5 +60,5 @@ jobs:
 
     - name: Test API startup
       run: |
-        poetry run python -c "from
+        poetry run python -c "from inception.embed_endpoint import app; assert app is not None"
 


### PR DESCRIPTION
This PR updates the Python version matrix in `test.yml` to ["3.9", "3.10", "3.11"], matching `pyproject.toml`. It also corrects an incomplete test API startup command and moves `black` and `mypy` to dev dependencies. Fixed a typo in a comment in `embed_endpoint.py` for better clarity. These changes help maintain consistency, optimize dependency management, and improve code readability.