### PR TITLE
Remove max_text_length limit and rely on chunking for long texts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,10 @@ numpy = "^1.26.1"
 gunicorn = "^21.2.0"
 prometheus-client = "^0.19.0"
 sentry-sdk = {extras = ["fastapi"], version = "^1.32.0"}
-black = "^23.11.0"
-mypy = "^1.7.0"
 
 [tool.poetry.group.dev.dependencies]
+black = "^23.11.0"
+mypy = "^1.7.0"
 pytest = "^7.4.3"
 pytest-cov = "^4.1.0"
 httpx = "^0.25.1"

--- a/test.yml
+++ b/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
       fail-fast: false  # Continue with other versions if one fails
 
     steps:
@@ -60,5 +60,5 @@ jobs:
 
     - name: Test API startup
       run: |
-        poetry run python -c "from
+        poetry run python -c "from inception.embed_endpoint import app; assert app is not None"
 


### PR DESCRIPTION
This PR removes the `max_text_length` limit, allowing for texts of any length to be processed. Relies on the chunking mechanism to split texts into smaller, manageable 350-word chunks. No changes to the minimum text length or batch size limits. These changes enhance flexibility in handling larger documents without risking memory overload.
