### PR TITLE
Remove max_text_length and ensure correct model is referenced

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,6 @@
 # Model Settings
 TRANSFORMER_MODEL_NAME=sentence-transformers/multi-qa-mpnet-base-dot-v1
 MAX_WORDS=350
-MAX_TEXT_LENGTH=100000
 MIN_TEXT_LENGTH=1
 MAX_BATCH_SIZE=100
 POOL_TIMEOUT=3600

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,7 +7,7 @@ services:
       - "8005:8005"
     environment:
       - EMBEDDING_WORKERS=2
-      - TRANSFORMER_MODEL_NAME=sentence-transformers/all-mpnet-base-v2
+      - TRANSFORMER_MODEL_NAME=sentence-transformers/multi-qa-mpnet-base-dot-v1
       - FORCE_CPU=false
       - ENABLE_METRICS=true
       - SENTRY_DSN=

--- a/inception/embed_endpoint.py
+++ b/inception/embed_endpoint.py
@@ -79,7 +79,6 @@ class Settings(BaseSettings):
         le=1000,
         description="Maximum words per chunk"
     )
-    max_text_length: int = 100000  # Maximum text length in characters, shall we / can we increase to 1 mln? 
     min_text_length: int = 1  # Minimum text length in characters
     max_batch_size: int = 100  # Maximum number of documents in a batch
     pool_timeout: int = 3600  # Timeout for multi-process pool operations (seconds)
@@ -467,7 +466,7 @@ async def create_text_embedding(request: Request):
         if text_length < settings.min_text_length:
             ERROR_COUNT.labels(endpoint='text', error_type='text_too_short').inc()
             raise HTTPException(
-                status_code=422, 
+                status_code=422,
                 detail=f"Text length ({text_length}) below minimum ({settings.min_text_length})"
             )
 
@@ -516,8 +515,6 @@ async def create_batch_text_embeddings(request: BatchTextRequest):
             text_length = len(doc.text)
             if text_length < settings.min_text_length:
                 raise ValueError(f"Document {doc.id}: Text length ({text_length}) below minimum ({settings.min_text_length})")
-            if text_length > settings.max_text_length:
-                raise ValueError(f"Document {doc.id}: Text length ({text_length}) exceeds maximum ({settings.max_text_length})")
 
         texts = [doc.text for doc in request.documents]
         embeddings_list = await embedding_service.generate_text_embeddings(texts)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,8 @@ import shutil
 @pytest.fixture
 def test_settings():
     return Settings(
-        transformer_model_name="sentence-transformers/all-mpnet-base-v2",
+        transformer_model_name="sentence-transformers/multi-qa-mpnet-base-dot-v1",
         max_words=350,
-        max_text_length=100000,
         min_text_length=1,
         max_batch_size=100,
         pool_timeout=3600,
@@ -20,7 +19,7 @@ def test_settings():
 
 @pytest.fixture
 def test_model():
-    return SentenceTransformer("sentence-transformers/all-mpnet-base-v2")
+    return SentenceTransformer("sentence-transformers/multi-qa-mpnet-base-dot-v1")
 
 @pytest.fixture
 def test_service(test_model, test_settings):

--- a/tests/test_embedding_service.py
+++ b/tests/test_embedding_service.py
@@ -138,12 +138,6 @@ class TestInputValidation:
                 "input": {"text": ""},
                 "expected_status": 422,
                 "expected_error": "text length (0) below minimum"
-            },
-            {
-                "name": "text too long",
-                "input": {"text": "a" * (settings.max_text_length + 1)},
-                "expected_status": 422,
-                "expected_error": "text length"
             }
         ]
         
@@ -163,12 +157,6 @@ class TestInputValidation:
                 "input": "",
                 "expected_status": 422,
                 "expected_error": "text length (0) below minimum"
-            },
-            {
-                "name": "text too long",
-                "input": "a" * (settings.max_text_length + 1),
-                "expected_status": 422,
-                "expected_error": "text length"
             },
             {
                 "name": "invalid UTF-8",


### PR DESCRIPTION
Removed `max_text_length` from settings and test files. Updated all files to ensure we consistently reference the model `sentence-transformers/multi-qa-mpnet-base-dot-v1`. Removed related validation checks and test cases that depended on max_text_length. Adjusted docker-compose and conftest to align with the correct model. Verified all occurrences across codebase.
